### PR TITLE
Handle additional values in google sync data

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,16 @@ For power users, you can bypass the manual CSV download and have the watch beam 
 1. Create a brand new [Google Sheet](https://sheets.google.com).
 2. Name it something like "Pebble Gym Logs".
 3. In the very first row of your sheet (Row 1), type out the following headers across the columns: **Date** | **Routine** | **Duration (s)** | **Exercise** | **Set #** | **Reps** | **Weight**.
-4. In the top menu, click **Extensions** > **Apps Script**.
+4. If you want to include any of the additional fields: Sensation, Accuracy, Density, Max HR, or Avg HR add them to Row 1 and uncomment the corresponding code (see step 5 below).
+5. In the top menu, click **Extensions** > **Apps Script**.
 
 ### Step 2: Add the Code
 1. Delete any code currently in the script editor.
 2. In this GitHub repository, open the file named [`google_sheets_script.gs`](https://github.com/oliverano95/GymTracker/blob/main/google_sheets_script.gs).
 3. Copy all the code from that file and paste it into your Google Apps Script editor.
-4. On line 8 of the code, change the `mySecretPassword` variable to a secure password of your choice.
-5. Click the **Save** icon (the floppy disk).
+4. On line 15 of the code, change the `mySecretPassword` variable to a secure password of your choice.
+5. If you want to include any of the additional fields on lines 53-66 of the code: Sensation, Accuracy, Density, Max HR, or Avg HR, uncomment them.
+6. Click the **Save** icon (the floppy disk).
 
 ### Step 3: Deploy as a Web App
 1. In the top right corner of the Apps Script editor, click the blue **Deploy** button > **New deployment**.

--- a/google_sheets_script.gs
+++ b/google_sheets_script.gs
@@ -37,7 +37,8 @@ function doPost(e) {
   var avgHr = parts[7];
   
   // Loop through the rest of the string to parse exercises and sets
-  // i was orignally set to 3, which lead to odd
+  // i was orignally set to 3, which messed up the first record of a session with 
+  // the extra values for sensation, accuracy, density, max hr, and avg hr 
   for (var i = 8; i < parts.length; i++) {
     // If the part is not a number, it is the exercise name
     if (isNaN(parts[i])) {

--- a/google_sheets_script.gs
+++ b/google_sheets_script.gs
@@ -29,9 +29,16 @@ function doPost(e) {
   
   var currentExercise = "";
   var setNum = 1;
+  var sensationTitles = ["Unstoppable", "Strong", "Normal", "Exhausted", "Struggled"];
+  var sensation = sensationTitles[5-parts[3]];
+  var accuracy = parts[4];
+  var density = parts[5];
+  var maxHr = parts[6];
+  var avgHr = parts[7];
   
   // Loop through the rest of the string to parse exercises and sets
-  for (var i = 3; i < parts.length; i++) {
+  // i was orignally set to 3, which lead to odd
+  for (var i = 8; i < parts.length; i++) {
     // If the part is not a number, it is the exercise name
     if (isNaN(parts[i])) {
       currentExercise = parts[i];
@@ -40,14 +47,25 @@ function doPost(e) {
       // If it is a number, it is the reps, and the next item is the weight
       var reps = parts[i];
       var weight = parts[i+1];
+      var currentRow = [date, routine, duration, currentExercise, setNum, reps, weight]
+
+      // uncomment below to add sensation to output
+      currentRow = currentRow.concat([sensation]);
+      // uncomment below to add accuracy to output
+      currentRow = currentRow.concat([accuracy]);
+      // uncomment below to add density to output
+      currentRow = currentRow.concat([density]);
+      // uncomment below to add maxHr to output
+      currentRow = currentRow.concat([maxHr]);
+      // uncomment below to add avgHr to output
+      currentRow = currentRow.concat([avgHr]);
       
       // Append the perfectly formatted row to the spreadsheet!
-      sheet.appendRow([date, routine, duration, currentExercise, setNum, reps, weight]);
+      sheet.appendRow(currentRow);
       
       setNum++;
       i++; // Skip the next index since we already grabbed the weight
     }
   }
-  
   return ContentService.createTextOutput("Success");
 }

--- a/google_sheets_script.gs
+++ b/google_sheets_script.gs
@@ -51,15 +51,19 @@ function doPost(e) {
       var currentRow = [date, routine, duration, currentExercise, setNum, reps, weight]
 
       // uncomment below to add sensation to output
-      currentRow = currentRow.concat([sensation]);
+      // currentRow = currentRow.concat([sensation]);
+      
       // uncomment below to add accuracy to output
-      currentRow = currentRow.concat([accuracy]);
+      // currentRow = currentRow.concat([accuracy]);
+      
       // uncomment below to add density to output
-      currentRow = currentRow.concat([density]);
+      // currentRow = currentRow.concat([density]);
+      
       // uncomment below to add maxHr to output
-      currentRow = currentRow.concat([maxHr]);
+      // currentRow = currentRow.concat([maxHr]);
+      
       // uncomment below to add avgHr to output
-      currentRow = currentRow.concat([avgHr]);
+      // currentRow = currentRow.concat([avgHr]);
       
       // Append the perfectly formatted row to the spreadsheet!
       sheet.appendRow(currentRow);


### PR DESCRIPTION
the Google sync script didn't handle the sensation, accuracy, density, max hr, and avg hr values sent to it, so that messed up the beginning of each sessions records, adding some extra rows, etc. 

I changed the loop counter to ignore those values as part of a rep, and added variables to capture them and add them to the end of each record (or not, they can be commented out).

(This fix was coded entirely  without the help of AI, because I'm old. ;-) )